### PR TITLE
qlean integration

### DIFF
--- a/client-cmds/qlean-cmd.sh
+++ b/client-cmds/qlean-cmd.sh
@@ -7,7 +7,7 @@ node_binary="$scriptDir/qlean/build/src/executable/qlean \
       --modules-dir $scriptDir/qlean/build/src/modules \
       --genesis $configDir/config.yaml \
       --validator-registry-path $configDir/validators.yaml \
-      --bootnodes $configDir/nodes.yaml
+      --bootnodes $configDir/nodes.yaml \
       --node-id $item --node-key /config/$privKeyPath \
       --listen-addr /ip4/0.0.0.0/udp/$quicPort/quic-v1"
 

--- a/client-cmds/qlean-cmd.sh
+++ b/client-cmds/qlean-cmd.sh
@@ -8,7 +8,7 @@ node_binary="$scriptDir/qlean/build/src/executable/qlean \
       --genesis $configDir/config.yaml \
       --validator-registry-path $configDir/validators.yaml \
       --bootnodes $configDir/nodes.yaml \
-      --node-id $item --node-key /config/$privKeyPath \
+      --node-id $item --node-key $configDir/$privKeyPath \
       --listen-addr /ip4/0.0.0.0/udp/$quicPort/quic-v1"
 
 node_docker=

--- a/client-cmds/qlean-cmd.sh
+++ b/client-cmds/qlean-cmd.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 
 #-----------------------qlean setup----------------------
-node_binary=
+# expects "qlean" submodule or symlink inside "lean-quickstart" root directory
+# https://github.com/qdrvm/qlean-mini
+node_binary="$scriptDir/qlean/build/src/executable/qlean \
+      --modules-dir $scriptDir/qlean/build/src/modules \
+      --genesis $configDir/config.yaml \
+      --validator-registry-path $configDir/validators.yaml \
+      --bootnodes $configDir/nodes.yaml
+      --node-id $item --node-key /config/$privKeyPath \
+      --listen-addr /ip4/0.0.0.0/udp/$quicPort/quic-v1 \
+      2>&1 | tee $dataDir/$item.log"
+
 node_docker=
 
 # choose either binary or docker
-node_setup="docker"
+node_setup="binary"

--- a/client-cmds/qlean-cmd.sh
+++ b/client-cmds/qlean-cmd.sh
@@ -9,8 +9,7 @@ node_binary="$scriptDir/qlean/build/src/executable/qlean \
       --validator-registry-path $configDir/validators.yaml \
       --bootnodes $configDir/nodes.yaml
       --node-id $item --node-key /config/$privKeyPath \
-      --listen-addr /ip4/0.0.0.0/udp/$quicPort/quic-v1 \
-      2>&1 | tee $dataDir/$item.log"
+      --listen-addr /ip4/0.0.0.0/udp/$quicPort/quic-v1"
 
 node_docker=
 

--- a/client-cmds/qlean-cmd.sh
+++ b/client-cmds/qlean-cmd.sh
@@ -12,7 +12,13 @@ node_binary="$scriptDir/qlean/build/src/executable/qlean \
       --node-id $item --node-key $configDir/$privKeyPath \
       --listen-addr /ip4/0.0.0.0/udp/$quicPort/quic-v1"
 
-node_docker=
+node_docker="--platform linux/amd64 qdrvm/qlean-mini:3f121fc \
+      --genesis /config/config.yaml \
+      --validator-registry-path /config/validators.yaml \
+      --bootnodes /config/nodes.yaml \
+      --data-dir /data \
+      --node-id $item --node-key /config/$privKeyPath \
+      --listen-addr /ip4/0.0.0.0/udp/$quicPort/quic-v1"
 
 # choose either binary or docker
-node_setup="binary"
+node_setup="docker"

--- a/client-cmds/qlean-cmd.sh
+++ b/client-cmds/qlean-cmd.sh
@@ -8,6 +8,7 @@ node_binary="$scriptDir/qlean/build/src/executable/qlean \
       --genesis $configDir/config.yaml \
       --validator-registry-path $configDir/validators.yaml \
       --bootnodes $configDir/nodes.yaml \
+      --data-dir $dataDir/$item \
       --node-id $item --node-key $configDir/$privKeyPath \
       --listen-addr /ip4/0.0.0.0/udp/$quicPort/quic-v1"
 

--- a/spin-node.sh
+++ b/spin-node.sh
@@ -3,6 +3,9 @@
 
 currentDir=$(pwd)
 scriptDir=$(dirname $0)
+if [ "$scriptDir" == "." ]; then
+  scriptDir="$currentDir"
+fi
 
 # 0. parse env and args
 source "$(dirname $0)/parse-env.sh"
@@ -47,12 +50,12 @@ then
 fi;
 
 # 4. run clients
-mkdir $dataDir
+mkdir -p $dataDir
 popupTerminalCmd="gnome-terminal --disable-factory --"
 for item in "${spin_nodes[@]}"; do
   # create and/or cleanup datadirs
   itemDataDir="$dataDir/$item"
-  mkdir $itemDataDir
+  mkdir -p $itemDataDir
   cmd="sudo rm -rf $itemDataDir/*"
   echo $cmd
   eval $cmd

--- a/spin-node.sh
+++ b/spin-node.sh
@@ -16,10 +16,7 @@ source "$(dirname $0)/set-up.sh"
 # should take config.yaml and validator-config.yaml and generate files
 # 1. nodes.yaml 2. validators.yaml 3. .key files for each of nodes
 
-# 2. get the client cmds with args set
-source "$scriptDir/$NETWORK_DIR/client_env.sh"
-
-# 3. collect the nodes that the user has asked us to spin and perform setup
+# 2. collect the nodes that the user has asked us to spin and perform setup
 if [ "$validatorConfig" == "genesis_bootnode" ] || [ -z "$validatorConfig" ]; then
     validator_config_file="$configDir/validator-config.yaml"
 else
@@ -49,7 +46,7 @@ then
   exit;
 fi;
 
-# 4. run clients
+# 3. run clients
 mkdir -p $dataDir
 popupTerminalCmd="gnome-terminal --disable-factory --"
 for item in "${spin_nodes[@]}"; do


### PR DESCRIPTION
- Integrate qlean
  - binary from branch https://github.com/qdrvm/qlean-mini/pull/25
- Script fixes and improvements
  - #9.
  - `wait` for `&` jobs, stops jobs on ctrl+c.
  - `tee` to log files.
  - use absolute `scriptDir`.
  - `mkdir -p` to suppress existing directory warning.
  - (optional) `rm` without `sudo`.