### PR TITLE
ream docker integration

### DIFF
--- a/client-cmds/ream-cmd.sh
+++ b/client-cmds/ream-cmd.sh
@@ -2,7 +2,13 @@
 
 #-----------------------ream setup----------------------
 node_binary=
-node_docker=
+node_docker="ghcr.io/reamlabs/ream:latest --data-dir /data \
+        lean_node \
+        --network /config/config.yaml \
+        --validator-registry-path /config/validators.yaml \
+        --bootnodes /config/nodes.yaml \
+        --node-id $item --node-key /config/$privKeyPath \
+        --socket-port $quicPort"
 
 # choose either binary or docker
 node_setup="docker"

--- a/local-devnet/parse-vc.sh
+++ b/local-devnet/parse-vc.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# TODO: parse validator-config to load values related to the $item
-# needed for ream and qlean (or any other client), zeam picks directly from validator-config
-# 1. load quic port and export it in $quicPort
-# 2. private key and dump it into a file $client.key and export it in $privKeyPath
-
-# $item, $configDir (genesis dir) is available here

--- a/parse-vc.sh
+++ b/parse-vc.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# TODO: parse validator-config to load values related to the $item
+# needed for ream and qlean (or any other client), zeam picks directly from validator-config
+# 1. load quic port and export it in $quicPort
+# 2. private key and dump it into a file $client.key and export it in $privKeyPath
+
+# $item, $configDir (genesis dir) is available here
+#
+# right now values are hardcoded
+if [ "$item" == "zeam_0" ]
+then
+  quicPort=9000
+fi;
+
+if [ "$item" == "ream_0" ]
+then
+  quicPort=9001
+fi;
+
+if [ "$item" == "qlean_0" ]
+then
+  quicPort=9002
+fi;
+
+# currently hardcoded inside genesis folder, otherwise parse validator config
+# and dump there
+privKeyPath=$item.key

--- a/spin-node.sh
+++ b/spin-node.sh
@@ -71,7 +71,10 @@ for item in "${spin_nodes[@]}"; do
       execCmd="sudo $execCmd"
     fi;
 
-    execCmd="$execCmd --name $item --network host -v $configDir:/config -v $dataDir/$item:/data $node_docker"
+    execCmd="$execCmd --name $item --network host \
+          -v $configDir:/config \
+          -v $dataDir/$item:/data \
+          $node_docker"
   fi;
 
   if [ -n "$popupTerminal" ]


### PR DESCRIPTION
run

edit nodes assignment in spin-nodes.sh to: `nodes=("zeam_0" "ream_0")` for just two nodes spinoff to test /debug interop between just two nodes
```bash
NETWORK_DIR=local-devnet ./spin-node.sh --node all --freshStart --popupTerminal
```

## Followup work needed

some hardcoded values right now in parse-vc.sh @GrapeBaBa pls parse validator-config.yaml here 