### PR TITLE
Add comma-separated node support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,20 @@ A single command line quickstart to spin up lean node(s)
 
 ## Scenarios
 
-### Quickly startup two zeam nodes as a local devnet
+### Quickly startup various nodes as a local devnet
 
 ```sh
 NETWORK_DIR=local-devnet ./spin-node.sh --node all --freshStart --popupTerminal
+```
+
+### Startup specific nodes only
+
+```sh
+# Run only zeam_0 and ream_0 nodes
+NETWORK_DIR=local-devnet ./spin-node.sh --node zeam_0,ream_0 --freshStart --popupTerminal
+
+# Run only a single node
+NETWORK_DIR=local-devnet ./spin-node.sh --node zeam_0 --freshStart --popupTerminal
 ```
   
 ## Args
@@ -21,16 +31,20 @@ NETWORK_DIR=local-devnet ./spin-node.sh --node all --freshStart --popupTerminal
 1. `NETWORK_DIR` is an env to specify the network directory. Should have a `genesis` directory with genesis config. A `data` folder will be created inside this `NETWORK_DIR` if not already there.
   `genesis` directory should have the following files
 
-    a. `validator_config.yaml` which has node setup information for all the bootnodes
+    a. `validator-config.yaml` which has node setup information for all the bootnodes
     b. `validators.yaml` which assigns validator indices
     c. `nodes.yaml` which has the enrs generated for each of the respective nodes.
     d. `config.yaml` the actual network config
 
 2. `--freshStart` reset the genesis time in the `config.yaml` to now
 3. `--popupTerminal` if you want to pop out new terminals to run the nodes, opens gnome terminals
-4. `--node` specify which node you want to run, use `all` to run all the nodes in a single go, otherwise you may specify which node you want to run from `validator_config.yaml`. 
-  The client is provided this input so as to parse the correct node configuration to startup the node.
-5. `--validatorConfig` is the path to specify your nodes `validator_config.yaml`, `validators.yaml` (for which `--node` is still the node key to index) if your node is not a bootnode. 
+4. `--node` specify which node(s) you want to run:
+   - Use `all` to run all the nodes in a single go
+   - Specify a single node name (e.g., `zeam_0`) to run just that node
+   - Use comma-separated node names (e.g., `zeam_0,ream_0`) to run multiple specific nodes
+   
+   The client is provided this input so as to parse the correct node configuration to startup the node.
+5. `--validatorConfig` is the path to specify your nodes `validator-config.yaml`, `validators.yaml` (for which `--node` is still the node key to index) if your node is not a bootnode. 
   If unspecified it assumes value of `genesis_bootnode` which is to say that your node config is to be picked from `genesis` folder with `--node` as the node key index.
   This value is further provided to the client so that they can parse the correct config information.
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ NETWORK_DIR=local-devnet ./spin-node.sh --node all --freshStart --popupTerminal
 ### Startup specific nodes only
 
 ```sh
-# Run only zeam_0 and ream_0 nodes
+# Run only zeam_0 and ream_0 nodes (comma-separated)
 NETWORK_DIR=local-devnet ./spin-node.sh --node zeam_0,ream_0 --freshStart --popupTerminal
+
+# Run only zeam_0 and ream_0 nodes (space-separated)
+NETWORK_DIR=local-devnet ./spin-node.sh --node "zeam_0 ream_0" --freshStart --popupTerminal
 
 # Run only a single node
 NETWORK_DIR=local-devnet ./spin-node.sh --node zeam_0 --freshStart --popupTerminal
@@ -42,6 +45,7 @@ NETWORK_DIR=local-devnet ./spin-node.sh --node zeam_0 --freshStart --popupTermin
    - Use `all` to run all the nodes in a single go
    - Specify a single node name (e.g., `zeam_0`) to run just that node
    - Use comma-separated node names (e.g., `zeam_0,ream_0`) to run multiple specific nodes
+   - Use whitespace-separated node names (e.g., `"zeam_0 ream_0"`) to run multiple specific nodes
    
    The client is provided this input so as to parse the correct node configuration to startup the node.
 5. `--validatorConfig` is the path to specify your nodes `validator-config.yaml`, `validators.yaml` (for which `--node` is still the node key to index) if your node is not a bootnode. 

--- a/local-devnet/genesis/config.yaml
+++ b/local-devnet/genesis/config.yaml
@@ -1,5 +1,5 @@
 # Genesis Settings
-GENESIS_TIME: 1759703713
+GENESIS_TIME: 1759704442
 
 # Validator Settings  
 VALIDATOR_COUNT: 3

--- a/local-devnet/genesis/config.yaml
+++ b/local-devnet/genesis/config.yaml
@@ -1,5 +1,5 @@
 # Genesis Settings
-GENESIS_TIME: 1759325984
+GENESIS_TIME: 1759703713
 
 # Validator Settings  
 VALIDATOR_COUNT: 3

--- a/spin-node.sh
+++ b/spin-node.sh
@@ -90,7 +90,7 @@ fi;
 
 # 3. run clients
 mkdir -p $dataDir
-popupTerminalCmd="gnome-terminal --"
+popupTerminalCmd="gnome-terminal --disable-factory --"
 spinned_pids=()
 for item in "${spin_nodes[@]}"; do
   # create and/or cleanup datadirs

--- a/spin-node.sh
+++ b/spin-node.sh
@@ -74,7 +74,6 @@ fi;
 
 # 3. run clients
 mkdir -p $dataDir
-# popupTerminalCmd="gnome-terminal --disable-factory --"
 popupTerminalCmd="gnome-terminal --"
 spinned_pids=()
 for item in "${spin_nodes[@]}"; do

--- a/spin-node.sh
+++ b/spin-node.sh
@@ -34,29 +34,33 @@ echo "Detected nodes: ${nodes[@]}"
 # nodes=("zeam_0" "ream_0" "qlean_0")
 spin_nodes=()
 
-# Parse comma-separated node names or handle single node/all
-if [ $node == "all" ]; then
+# Parse comma-separated or space-separated node names or handle single node/all
+if [[ "$node" == "all" ]]; then
   # Spin all nodes
   spin_nodes=("${nodes[@]}")
   node_present=true
 else
-  # Split by comma to handle comma-separated node names
-  IFS=',' read -r -a requested_nodes <<< "$node"
+  # Handle both comma-separated and space-separated node names
+  if [[ "$node" == *","* ]]; then
+    IFS=',' read -r -a requested_nodes <<< "$node"
+  else
+    IFS=' ' read -r -a requested_nodes <<< "$node"
+  fi
 
   # Check each requested node against available nodes
-  for requested in "${requested_nodes[@]}"; do
-    found=false
-    for item in "${nodes[@]}"; do
-      if [ "$requested" == "$item" ]; then
-        spin_nodes+=("$item")
+  for requested_node in "${requested_nodes[@]}"; do
+    node_found=false
+    for available_node in "${nodes[@]}"; do
+      if [[ "$requested_node" == "$available_node" ]]; then
+        spin_nodes+=("$available_node")
         node_present=true
-        found=true
+        node_found=true
         break
       fi
     done
 
-    if [ "$found" == false ]; then
-      echo "Error: Node '$requested' not found in validator config"
+    if [[ "$node_found" == false ]]; then
+      echo "Error: Node '$requested_node' not found in validator config"
       echo "Available nodes: ${nodes[@]}"
       exit 1
     fi

--- a/spin-node.sh
+++ b/spin-node.sh
@@ -33,22 +33,45 @@ fi
 echo "Detected nodes: ${nodes[@]}"
 # nodes=("zeam_0" "ream_0" "qlean_0")
 spin_nodes=()
-for item in "${nodes[@]}"; do
-  if [ $node == $item ] || [ $node == "all" ]
-  then
-    node_present=true
-    spin_nodes+=($item)
-  fi;
-done
-if [ ! -n "$node_present" ] && [ node != "all" ]
-then
+
+# Parse comma-separated node names or handle single node/all
+if [ $node == "all" ]; then
+  # Spin all nodes
+  spin_nodes=("${nodes[@]}")
+  node_present=true
+else
+  # Split by comma to handle comma-separated node names
+  IFS=',' read -r -a requested_nodes <<< "$node"
+
+  # Check each requested node against available nodes
+  for requested in "${requested_nodes[@]}"; do
+    found=false
+    for item in "${nodes[@]}"; do
+      if [ "$requested" == "$item" ]; then
+        spin_nodes+=("$item")
+        node_present=true
+        found=true
+        break
+      fi
+    done
+
+    if [ "$found" == false ]; then
+      echo "Error: Node '$requested' not found in validator config"
+      echo "Available nodes: ${nodes[@]}"
+      exit 1
+    fi
+  done
+fi
+
+if [ ! -n "$node_present" ]; then
   echo "invalid specified node, options =${nodes[@]} all, exiting."
   exit;
 fi;
 
 # 3. run clients
 mkdir -p $dataDir
-popupTerminalCmd="gnome-terminal --disable-factory --"
+# popupTerminalCmd="gnome-terminal --disable-factory --"
+popupTerminalCmd="gnome-terminal --"
 spinned_pids=()
 for item in "${spin_nodes[@]}"; do
   # create and/or cleanup datadirs


### PR DESCRIPTION
Fixes #14 

### Changes
- Add support for comma-separated node names: `--node zeam_0,ream_0`
- Add support for space-separated node names: `--node "zeam_0 ream_0"`
- Fix gnome-terminal compatibility on modern systems
- Minor stability fixes
- Documentation update

### Examples
```bash
# Run specific nodes (comma-separated)
./spin-node.sh --node zeam_0,ream_0

# Run specific nodes (space-separated)  
./spin-node.sh --node "zeam_0 ream_0"

# Run single node
./spin-node.sh --node zeam_0

# Run all nodes
./spin-node.sh --node all
```
