### PR TITLE
fix yq string interpolation

### DIFF
--- a/generate-genesis.sh
+++ b/generate-genesis.sh
@@ -321,11 +321,11 @@ fi
 
 # Display individual validator counts for transparency
 echo "   Individual validator counts:"
-while IFS= read -r line; do
-    validator_name=$(echo "$line" | cut -d: -f1)
-    validator_count=$(echo "$line" | cut -d: -f2 | xargs)
+while IFS= read -r validator_name; do
+    # Use simple yq expression per validator to avoid cross-version quirks
+    validator_count=$(yq eval ".validators[] | select(.name == \"$validator_name\") | .count" "$VALIDATOR_CONFIG_FILE")
     echo "     - $validator_name: $validator_count"
-done < <(yq eval '.validators[] | "\(.name):\(.count)"' "$VALIDATOR_CONFIG_FILE")
+done < <(yq eval '.validators[].name' "$VALIDATOR_CONFIG_FILE")
 
 echo "   Total validator count: $TOTAL_VALIDATORS"
 


### PR DESCRIPTION
fixes this https://github.com/blockblaz/lean-quickstart/issues/60

I was unable to reproduce this locally, mine executed without errors 
my yq version: v4.48.1

I implemented the fix because
The error message  showed  here indicates a parsing issue with tostring, tostring isn't a standard yq v4 function in all versions, string interpolation ("\(.name):\(.count)") is more reliable and compatible.