### PR TITLE
Feat: use ssz encoded validator key generation

### DIFF
--- a/generate-genesis.sh
+++ b/generate-genesis.sh
@@ -225,7 +225,7 @@ else
       --num-validators "$VALIDATOR_COUNT" \
       --log-num-active-epochs "$ACTIVE_EPOCH" \
       --output-dir "/genesis/hash-sig-keys" \
-      --export-format ssz
+      --export-format both
 
     if [ $? -ne 0 ]; then
         echo "   ❌ Failed to generate hash-sig keys"


### PR DESCRIPTION
## Description

Since we are moving to SSZ encoded keys, this PR adds the necessary flag that generates ssz encoded keys using hash-sig-cli. 

## Dependencies
1) SSZ encoding support in hash-sig-cli: https://github.com/blockblaz/hash-sig-cli/pull/28
2) Working hash-sig-cli docker image: https://github.com/blockblaz/hash-sig-cli/pull/29