### PR TITLE
fix: remove ream devnet flag

### DIFF
--- a/client-cmds/ream-cmd.sh
+++ b/client-cmds/ream-cmd.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 
 #-----------------------ream setup----------------------
-devnet_flag=""
-if [ -n "$devnet" ]; then
-        devnet_flag="--devnet $devnet"
-fi
-
 # Metrics enabled by default
 metrics_flag="--metrics"
 
@@ -14,7 +9,6 @@ node_binary="$scriptDir/../ream/target/release/ream --data-dir $dataDir/$item \
         lean_node \
         --network $configDir/config.yaml \
         --validator-registry-path $configDir/validators.yaml \
-        $devnet_flag \
         --bootnodes $configDir/nodes.yaml \
         --node-id $item --node-key $configDir/$privKeyPath \
         --socket-port $quicPort \
@@ -27,7 +21,6 @@ node_docker="ghcr.io/reamlabs/ream:latest --data-dir /data \
         lean_node \
         --network /config/config.yaml \
         --validator-registry-path /config/validators.yaml \
-        $devnet_flag \
         --bootnodes /config/nodes.yaml \
         --node-id $item --node-key /config/$privKeyPath \
         --socket-port $quicPort \


### PR DESCRIPTION
## Summary

Recently ream removed support for the runtime-based flag (https://github.com/ReamLabs/ream/pull/1099). This PR removes the deprecated devnet flags that were causing launch failures in both docker and binary modes.

## Important Note
Since the devnet selection is now a compile-time feature, you must ensure that your ream binary is built with the appropriate feature flag enabled if you are using the binary setup mode.

1. For example, to build for devnet1 (default):

    ```
    cargo build --release --features devnet1
    ```

2. For devnet2:

    ```
    cargo build --release --no-default-features --features devnet2
    ```

 NOTE: If you are using the docker image, ensure the image is built with the desired feature enabled.
