### PR TITLE
ci: auto-release workflow (zeam-aligned)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -2,197 +2,265 @@ name: Auto Release on Main Branch
 
 on:
   pull_request:
-    types: [ closed ]
-    branches: [ main ]
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: write
 
 jobs:
-  auto-release:
-    # Only run if PR was merged from release branch to main and contains release label
-    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'release' && contains(github.event.pull_request.labels.*.name, 'release')
+  create-tags:
+    # Only run if PR was merged to main from release branch and has release label
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'release' &&
+      contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_tags_labels.outputs.version }}
+      devnet_tag: ${{ steps.get_tags_labels.outputs.devnet_tag }}
+      docker_tag: ${{ steps.get_tags_labels.outputs.docker_tag }}
+      github_tag: ${{ steps.get_tags_labels.outputs.github_tag }}
+      has_devnet_tag: ${{ steps.get_tags_labels.outputs.has_devnet_tag }}
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Extract and validate required labels
-      id: get_labels
-      run: |
-        # Get PR labels
-        LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
-        echo "PR Labels: $LABELS"
+      - name: Extract tags from PR labels
+        id: get_tags_labels
+        run: |
+          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+          echo "PR Labels: $LABELS"
 
-        # Look for version label in x.x.x format (e.g., "1.0.0", "2.1.3") - MANDATORY
-        VERSION=$(echo $LABELS | jq -r '.[] | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))')
+          VERSION=$(echo $LABELS | jq -r '.[] | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))' | head -n 1)
 
-        # Look for devnet labels (devnet0, devnet1, devnet2, etc.) - MANDATORY
-        DEVNET_LABEL=$(echo $LABELS | jq -r '.[] | select(test("^devnet[0-9]+$"))')
+          DEVNET_TAG_LOWER=$(echo $LABELS | jq -r '.[] | select(test("^devnet[0-9]+$"))' | head -n 1)
 
-        # Check for mandatory labels - both version and devnet are required
-        MISSING_LABELS=""
-
-        if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
-          MISSING_LABELS="version label (e.g., 1.0.0)"
-        fi
-
-        if [ -z "$DEVNET_LABEL" ] || [ "$DEVNET_LABEL" = "null" ]; then
-          if [ -n "$MISSING_LABELS" ]; then
-            MISSING_LABELS="$MISSING_LABELS and devnet label (devnet0, devnet1, devnet2, etc.)"
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "❌ Version label is mandatory! Please add a version label in x.y.z format (e.g. 1.0.0)"
+            exit 1
           else
-            MISSING_LABELS="devnet label (devnet0, devnet1, devnet2, etc.)"
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "git_tag=v$VERSION" >> $GITHUB_OUTPUT
+            echo "✅ Version found: $VERSION"
           fi
-        fi
 
-        # Exit if any required labels are missing
-        if [ -n "$MISSING_LABELS" ]; then
-          echo "❌ Missing required labels: $MISSING_LABELS"
-          echo "Please add all required labels to proceed with the release."
-          exit 1
-        fi
+          if [ -n "$DEVNET_TAG_LOWER" ] && [ "$DEVNET_TAG_LOWER" != "null" ]; then
+            DOCKER_TAG="$DEVNET_TAG_LOWER"
+            GITHUB_TAG="D${DEVNET_TAG_LOWER:1}"
 
-        # Check if version tag already exists (add 'v' prefix for git tag)
-        VERSION_TAG="v$VERSION"
-        if git rev-parse "$VERSION_TAG" >/dev/null 2>&1; then
-          echo "❌ Version tag $VERSION_TAG already exists. Please use a new version."
-          exit 1
-        fi
+            echo "devnet_tag=$DOCKER_TAG" >> $GITHUB_OUTPUT
+            echo "docker_tag=$DOCKER_TAG" >> $GITHUB_OUTPUT
+            echo "github_tag=$GITHUB_TAG" >> $GITHUB_OUTPUT
+            echo "has_devnet_tag=true" >> $GITHUB_OUTPUT
+            echo "✅ Found devnet tag: label=$DEVNET_TAG_LOWER -> docker_tag=$DOCKER_TAG, github_tag=$GITHUB_TAG"
+          else
+            echo "has_devnet_tag=false" >> $GITHUB_OUTPUT
+            echo "ℹ️ No devnet tag found (optional)"
+          fi
 
-        # Create proper naming to avoid branch/tag conflicts
-        DEVNET_TAG="$(echo $DEVNET_LABEL | sed 's/^d/D/')"  # devnet1 -> Devnet1
-        DEVNET_BRANCH="$DEVNET_LABEL"                        # devnet1
+      - name: Create and push git tags
+        id: create_tags
+        run: |
+          git fetch --prune --tags --force
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-        # Set outputs only after validation passes
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-        echo "git_tag=$VERSION_TAG" >> $GITHUB_OUTPUT
-        echo "devnet_label=$DEVNET_LABEL" >> $GITHUB_OUTPUT
-        echo "devnet_tag=$DEVNET_TAG" >> $GITHUB_OUTPUT
-        echo "devnet_branch=$DEVNET_BRANCH" >> $GITHUB_OUTPUT
-        echo "✅ Found version: $VERSION and devnet label: $DEVNET_LABEL"
-        echo "✅ Will create branch: $DEVNET_BRANCH and tag: $DEVNET_TAG"
+          CREATE_VERSION_TAG=false
+          CREATE_DEVNET_TAG=false
 
-        echo "✅ All required labels validated"
+          if [ -n "${{ steps.get_tags_labels.outputs.version }}" ] && [ "${{ steps.get_tags_labels.outputs.version }}" != "null" ]; then
+            if git rev-parse "${{ steps.get_tags_labels.outputs.git_tag }}" >/dev/null 2>&1; then
+              echo "❌ Version tag ${{ steps.get_tags_labels.outputs.git_tag }} already exists. Please use a different version label."
+              exit 1
+            else
+              CREATE_VERSION_TAG=true
+            fi
+          fi
 
-    - name: Delete existing devnet tag and release if present
-      run: |
-        DEVNET_TAG="${{ steps.get_labels.outputs.devnet_tag }}"
+          if [ "${{ steps.get_tags_labels.outputs.has_devnet_tag }}" = "true" ]; then
+            DEVNET_GIT_TAG="${{ steps.get_tags_labels.outputs.github_tag }}"
 
-        # Check if tag exists and delete it
-        if git rev-parse "$DEVNET_TAG" >/dev/null 2>&1; then
-          echo "🗑️ Deleting existing tag $DEVNET_TAG"
-          git tag -d "$DEVNET_TAG" 2>/dev/null || true
-          git push origin --delete "$DEVNET_TAG" 2>/dev/null || true
-          echo "✅ Deleted existing tag $DEVNET_TAG"
-        else
-          echo "ℹ️ Tag $DEVNET_TAG does not exist"
-        fi
+            if git rev-parse "$DEVNET_GIT_TAG" >/dev/null 2>&1; then
+              echo "🗑️ Devnet tag $DEVNET_GIT_TAG already exists, will be recreated"
+              git tag -d "$DEVNET_GIT_TAG" || echo "⚠️ Local tag deletion failed"
+              git push --delete origin "$DEVNET_GIT_TAG" || echo "⚠️ Remote tag deletion failed"
+            fi
+            CREATE_DEVNET_TAG=true
+          fi
 
-        # Delete GitHub release if it exists
-        echo "🗑️ Attempting to delete existing GitHub release $DEVNET_TAG"
-        gh release delete "$DEVNET_TAG" --yes 2>/dev/null || echo "ℹ️ Release $DEVNET_TAG does not exist or already deleted"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          if [ "$CREATE_VERSION_TAG" = "true" ]; then
+            git tag -a "${{ steps.get_tags_labels.outputs.git_tag }}" -m "Release version ${{ steps.get_tags_labels.outputs.version }}"
+            git push origin "${{ steps.get_tags_labels.outputs.git_tag }}"
+            echo "✅ Created version tag ${{ steps.get_tags_labels.outputs.git_tag }}"
+          fi
 
-    - name: Create/Update devnet branch
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [ "$CREATE_DEVNET_TAG" = "true" ]; then
+            git tag -a "$DEVNET_GIT_TAG" -m "Devnet release for $DEVNET_GIT_TAG"
+            git push origin "$DEVNET_GIT_TAG"
+            echo "✅ Created devnet git tag $DEVNET_GIT_TAG"
+          fi
+          echo "create_version_tag=$CREATE_VERSION_TAG" >> $GITHUB_OUTPUT
+          echo "create_devnet_tag=$CREATE_DEVNET_TAG" >> $GITHUB_OUTPUT
 
-        DEVNET_BRANCH="${{ steps.get_labels.outputs.devnet_branch }}"
+  create-github-release:
+    needs: [create-tags]
+    runs-on: ubuntu-latest
+    if: ${{ needs.create-tags.outputs.has_devnet_tag == 'true' }}
 
-        # Check if devnet branch already exists remotely
-        if git ls-remote --heads origin "$DEVNET_BRANCH" | grep -q "$DEVNET_BRANCH"; then
-          echo "ℹ️ Branch $DEVNET_BRANCH already exists remotely"
-          git checkout "$DEVNET_BRANCH"
-          git pull origin "$DEVNET_BRANCH"
-        else
-          echo "✅ Creating new branch $DEVNET_BRANCH from main"
-          git checkout -b "$DEVNET_BRANCH"
-        fi
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-        # Merge latest main changes into devnet branch
-        git merge main --no-ff -m "Merge main into $DEVNET_BRANCH for deployment"
-        git push -u origin "$DEVNET_BRANCH"
-        echo "✅ Updated branch $DEVNET_BRANCH with latest main changes"
+      - name: Delete existing devnet release if exists
+        run: |
+          DEVNET_TAG="${{ needs.create-tags.outputs.github_tag }}"
+          echo "🔍 Checking for existing $DEVNET_TAG release..."
+          if gh api repos/${{ github.repository }}/releases/tags/$DEVNET_TAG >/dev/null 2>&1; then
+            RELEASE_ID=$(gh api repos/${{ github.repository }}/releases/tags/$DEVNET_TAG --jq '.id')
+            echo "🗑️ Found existing GitHub release for $DEVNET_TAG (ID: $RELEASE_ID), deleting..."
+            gh api --method DELETE repos/${{ github.repository }}/releases/$RELEASE_ID
+            echo "✅ Deleted existing GitHub release"
+          else
+            echo "ℹ️ No existing GitHub release found for $DEVNET_TAG"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-        # Switch back to main for tagging
-        git checkout main
+      - name: Generate changelog from previous release
+        id: changelog
+        run: |
+          DEVNET_TAG="${{ needs.create-tags.outputs.github_tag }}"
+          PREVIOUS_TAG=$(git tag -l | grep -iE "^[Dd]evnet[0-9]+" | sort -V -r | grep -v "^$DEVNET_TAG$" | head -1)
 
-    - name: Generate changelog
-      id: changelog
-      run: |
-        # Get the last devnet tag for changelog comparison
-        CURRENT_DEVNET_TAG="${{ steps.get_labels.outputs.devnet_tag }}"
-        DEVNET_TAG_PREFIX="$(echo ${{ steps.get_labels.outputs.devnet_label }} | sed 's/^d/D/')"
-        LAST_DEVNET_TAG=$(git tag -l "${DEVNET_TAG_PREFIX}*" --sort=-version:refname | grep -v "^$CURRENT_DEVNET_TAG$" | head -n 1)
+          if [ -n "$PREVIOUS_TAG" ] && [ "$PREVIOUS_TAG" != "$DEVNET_TAG" ]; then
+            echo "✅ Found previous tag: $PREVIOUS_TAG"
+            echo "📝 Generating changelog from $PREVIOUS_TAG to current release..."
 
-        if [ -z "$LAST_DEVNET_TAG" ]; then
-          echo "ℹ️ No previous devnet tag found, generating changelog from last 20 commits"
-          # Get commits with author and PR info for GitHub-style format
-          CHANGELOG=$(git log --oneline --pretty=format:"- %s by @%an in %h" | head -20 | sed 's/ by @/ by @/g' | sed 's/ in / in #/g')
-        else
-          echo "ℹ️ Generating changelog from $LAST_DEVNET_TAG to current"
-          # Get commits between tags with author and PR info
-          CHANGELOG=$(git log --oneline --pretty=format:"- %s by @%an in %h" $LAST_DEVNET_TAG..HEAD | sed 's/ by @/ by @/g' | sed 's/ in / in #/g')
-        fi
+            COMMIT_LOG=$(git log --pretty=format:"- %s (%h)" --no-merges "$PREVIOUS_TAG"..HEAD)
+            FILES_CHANGED=$(git diff --name-only "$PREVIOUS_TAG"..HEAD | wc -l)
+            INSERTIONS=$(git diff --shortstat "$PREVIOUS_TAG"..HEAD | grep -o '[0-9]\+ insertion' | grep -o '[0-9]\+' || echo "0")
+            DELETIONS=$(git diff --shortstat "$PREVIOUS_TAG"..HEAD | grep -o '[0-9]\+ deletion' | grep -o '[0-9]\+' || echo "0")
+            CONTRIBUTORS=$(git log --pretty=format:"%an" --no-merges "$PREVIOUS_TAG"..HEAD | sort | uniq | tr '\n' ', ' | sed 's/, $//')
 
-        # If no commits found, add a default message
-        if [ -z "$CHANGELOG" ]; then
-          CHANGELOG="- No changes found in this release"
-        fi
+            CHANGELOG="## 📋 Changes since $PREVIOUS_TAG
 
-        # Create release notes with GitHub-style changelog
-        cat > release_notes.md << EOF
-        # Release Notes
+          ### 📊 Summary
+          - **Files changed**: $FILES_CHANGED
+          - **Insertions**: +$INSERTIONS
+          - **Deletions**: -$DELETIONS
+          - **Contributors**: $CONTRIBUTORS
 
-        **Network:** ${{ steps.get_labels.outputs.devnet_label }}
-        **Version:** ${{ steps.get_labels.outputs.version }}
-        **Tag:** ${{ steps.get_labels.outputs.devnet_tag }}
-        **Branch:** ${{ steps.get_labels.outputs.devnet_branch }}
-        **Date:** $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+          ### 🔄 Recent commits
+          $COMMIT_LOG
 
-        ## What's Changed
+          ### 🔗 Compare changes
+          [View full diff](${{ github.server_url }}/${{ github.repository }}/compare/$PREVIOUS_TAG...HEAD)"
 
-        ${CHANGELOG}
+          else
+            echo "ℹ️ No previous release found or this is the first release"
+            CHANGELOG="## 📋 Changes
 
-        **Full Changelog**: https://github.com/${{ github.repository }}/commits/${{ steps.get_labels.outputs.devnet_tag }}
+          This is the first devnet release for lean-quickstart."
+          fi
 
-        EOF
+          echo "changelog<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "previous_tag=$PREVIOUS_TAG" >> $GITHUB_OUTPUT
 
-        echo "✅ Generated changelog with $(echo "$CHANGELOG" | wc -l) commits"
-        echo "changelog_file=release_notes.md" >> $GITHUB_OUTPUT
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.create-tags.outputs.github_tag }}
+          name: "lean-quickstart ${{ needs.create-tags.outputs.github_tag }} Release"
+          body: |
+            # lean-quickstart ${{ needs.create-tags.outputs.github_tag }} Release
 
-    - name: Create and push tags on main
-      id: create_tags
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
+            ## Release information
+            - **Version**: ${{ needs.create-tags.outputs.version }}
+            - **Network tag**: ${{ needs.create-tags.outputs.github_tag }}
+            - **Branch**: `${{ needs.create-tags.outputs.docker_tag }}` (updated from `main` after merge)
 
-        VERSION_TAG="${{ steps.get_labels.outputs.git_tag }}"
-        DEVNET_TAG="${{ steps.get_labels.outputs.devnet_tag }}"
+            This repository provides devnet tooling (Ansible, scripts, genesis helpers). Client container images are published from the [zeam](https://github.com/blockblaz/zeam) repository.
 
-        # Create version tag on main
-        git tag -a "$VERSION_TAG" -m "Release version ${{ steps.get_labels.outputs.version }}"
-        git push origin "$VERSION_TAG"
-        echo "✅ Created version tag $VERSION_TAG on main branch"
+            ## 📋 Changes
+            ${{ steps.changelog.outputs.changelog }}
 
-        # Create devnet tag on main (already deleted if existed)
-        git tag -a "$DEVNET_TAG" -m "Devnet deployment tag for $DEVNET_TAG"
-        git push origin "$DEVNET_TAG"
-        echo "✅ Created devnet tag $DEVNET_TAG on main branch"
+            ## 🌿 Use this release
+            ```bash
+            git fetch origin tag ${{ needs.create-tags.outputs.github_tag }}
+            git checkout ${{ needs.create-tags.outputs.github_tag }}
+            ```
+          draft: false
+          prerelease: true
 
-    - name: Create GitHub Release
-      uses: softprops/action-gh-release@v1
-      with:
-        tag_name: ${{ steps.get_labels.outputs.devnet_tag }}
-        name: Release ${{ steps.get_labels.outputs.version }} - ${{ steps.get_labels.outputs.devnet_tag }}
-        body_path: ${{ steps.changelog.outputs.changelog_file }}
-        draft: false
-        prerelease: true
-        target_commitish: main
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push code to corresponding devnet branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          GITHUB_TAG="${{ needs.create-tags.outputs.github_tag }}"
+          DOCKER_TAG="${{ needs.create-tags.outputs.docker_tag }}"
+          DEVNET_BRANCH="$DOCKER_TAG"
+
+          git fetch origin main
+
+          echo "✅ GitHub tag: $GITHUB_TAG, branch: $DEVNET_BRANCH"
+          if git ls-remote --heads origin "$DEVNET_BRANCH" | grep -q "$DEVNET_BRANCH"; then
+            echo "✅ $DEVNET_BRANCH branch exists, updating it"
+            git fetch origin "$DEVNET_BRANCH"
+            git checkout "$DEVNET_BRANCH"
+            git merge origin/main --no-edit
+          else
+            echo "✅ $DEVNET_BRANCH branch doesn't exist, creating it from current main"
+            git checkout -b "$DEVNET_BRANCH"
+          fi
+
+          git push origin "$DEVNET_BRANCH"
+          echo "✅ Successfully pushed code to $DEVNET_BRANCH branch"
+
+      - name: Send Telegram success notification
+        if: ${{ success() }}
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then
+            echo "ℹ️ Telegram secrets not set; skipping notification"
+            exit 0
+          fi
+
+          DOCKER_TAG="${{ needs.create-tags.outputs.docker_tag }}"
+          GITHUB_TAG="${{ needs.create-tags.outputs.github_tag }}"
+          VERSION="${{ needs.create-tags.outputs.version }}"
+          REPO_URL="${{ github.server_url }}/${{ github.repository }}"
+
+          MESSAGE="🚀 *lean-quickstart $GITHUB_TAG release SUCCESS*
+
+          *Release details:*
+          • Version: \`$VERSION\`
+          • Network: \`$GITHUB_TAG\`
+          • Repository: [${{ github.repository }}]($REPO_URL)
+
+          *🔗 Links:*
+          • [GitHub release]($REPO_URL/releases/tag/$GITHUB_TAG)
+
+          *🌿 Branch:*
+          • Code pushed to \`$DOCKER_TAG\`
+
+          _Automated release notification_"
+
+          curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"chat_id\": \"${TELEGRAM_CHAT_ID}\",
+              \"text\": \"$MESSAGE\",
+              \"parse_mode\": \"Markdown\",
+              \"disable_web_page_preview\": true
+            }" && echo "📱 Telegram notification sent successfully" || echo "❌ Failed to send Telegram notification"


### PR DESCRIPTION
## Summary
Adds `.github/workflows/auto-release.yml` aligned with the zeam release process: PR from `release` → `main` with `release` + semver labels, optional `devnetN` tag, git tags, GitHub prerelease + changelog, devnet branch sync, optional Telegram.

No Docker build (lean-quickstart is tooling-only); points to zeam for client images in the release notes.