### PR TITLE
client-cmds/nlean: switch to --custom-network-config-dir

### DIFF
--- a/client-cmds/nlean-cmd.sh
+++ b/client-cmds/nlean-cmd.sh
@@ -60,16 +60,14 @@ binary_path="$nlean_repo/artifacts/lean-client/Lean.Client"
 mkdir -p "$dataDir/$item"
 
 node_binary="$binary_path \
-      --validator-config $configDir/validator-config.yaml \
+      --custom-network-config-dir $configDir \
       --node $item \
       --data-dir $dataDir/$item \
-      --network $nlean_network_name \
       --node-key $configDir/$node_private_key_path \
       --socket-port $quicPort \
       --metrics $enable_metrics \
       --metrics-port $metricsPort \
       --metrics-address 0.0.0.0 \
-      --hash-sig-key-dir $configDir/hash-sig-keys \
       $api_port_flag \
       $attestation_committee_flag \
       $aggregator_flag \
@@ -103,16 +101,14 @@ if [[ -n "${NLEAN_DEBUG_DUMP_OBSERVED_BLOCKS_DIR:-}" ]]; then
 fi
 
 node_docker="${nlean_docker_extra_env} ${nlean_docker_image} \
-      --validator-config /config/validator-config.yaml \
+      --custom-network-config-dir /config \
       --node $item \
       --data-dir /data \
-      --network $nlean_network_name \
       --node-key /config/$node_private_key_path \
       --socket-port $quicPort \
       --metrics $enable_metrics \
       --metrics-port $metricsPort \
       --metrics-address 0.0.0.0 \
-      --hash-sig-key-dir /config/hash-sig-keys \
       $api_port_flag \
       $attestation_committee_flag \
       $aggregator_flag \


### PR DESCRIPTION
## Summary

nlean v0.3.10-devnet4 adds support for `--custom-network-config-dir` — the single-flag convention that ethlambda / gean / zeam already follow. One path under which the binary auto-discovers `config.yaml`, `nodes.yaml`, `annotated_validators.yaml`, `hash-sig-keys/`, and `<node>.key`.

This PR switches `client-cmds/nlean-cmd.sh` to the shared flag, dropping the bespoke `--validator-config` + `--annotated-validators` + `--hash-sig-key-dir` + `--network` combo.

Locally verified with a 2nlean + 2ethlambda devnet (both using `--custom-network-config-dir`) — reached finalization inside ~50 slots.

## Test plan

- [ ] `NETWORK_DIR=local-devnet-nlean ./spin-node.sh --node all` boots nlean and produces/accepts blocks
- [ ] Mixed-client interop with ethlambda / gean / zeam still finalizes