### PR TITLE
chore: update ethlambda CLI flags to align with the spec

### DIFF
--- a/ansible/roles/ethlambda/tasks/main.yml
+++ b/ansible/roles/ethlambda/tasks/main.yml
@@ -95,7 +95,11 @@
         -v {{ genesis_dir }}:/config:ro
         -v {{ data_dir }}/{{ node_name }}:/data
         {{ ethlambda_docker_image }}
-        --custom-network-config-dir /config
+        --genesis /config/config.yaml
+        --validators /config/annotated_validators.yaml
+        --bootnodes /config/nodes.yaml
+        --validator-config /config/validator-config.yaml
+        --hash-sig-keys-dir /config/hash-sig-keys
         --data-dir /data
         --gossipsub-port {{ ethlambda_quic_port }}
         --node-id {{ node_name }}

--- a/client-cmds/ethlambda-cmd.sh
+++ b/client-cmds/ethlambda-cmd.sh
@@ -24,7 +24,11 @@ fi
 
 # Command when running as binary
 node_binary="$binary_path \
-      --custom-network-config-dir $configDir \
+      --genesis $configDir/config.yaml \
+      --validators $configDir/annotated_validators.yaml \
+      --bootnodes $configDir/nodes.yaml \
+      --validator-config $configDir/validator-config.yaml \
+      --hash-sig-keys-dir $configDir/hash-sig-keys \
       --data-dir $dataDir/$item \
       --gossipsub-port $quicPort \
       --node-id $item \
@@ -38,7 +42,11 @@ node_binary="$binary_path \
 
 # Command when running as docker container
 node_docker="ghcr.io/lambdaclass/ethlambda:devnet3 \
-      --custom-network-config-dir /config \
+      --genesis /config/config.yaml \
+      --validators /config/annotated_validators.yaml \
+      --bootnodes /config/nodes.yaml \
+      --validator-config /config/validator-config.yaml \
+      --hash-sig-keys-dir /config/hash-sig-keys \
       --data-dir /data \
       --gossipsub-port $quicPort \
       --node-id $item \


### PR DESCRIPTION
## Description

Aligns ethlambda's CLI flags with the [client cli flags spec](https://github.com/blockblaz/lean-quickstart/blob/main/docs/adding-a-new-client.md#required-cli-flags-your-client-must-support).

## Changes:

In `client-cmds/ethlambda-cmd.sh`, both the `node_binary` and `node_docker` invocations now pass the following flags instead of the single `--custom-network-config-dir`:

  | Flag | Path |
  |---|---|
  | `--genesis` | `<config_dir>/config.yaml` |
  | `--validators` | `<config_dir>/annotated_validators.yaml` |
  | `--bootnodes` | `<config_dir>/nodes.yaml` |
  | `--validator-config` | `<config_dir>/validator-config.yaml` |
  | `--hash-sig-keys-dir` | `<config_dir>/hash-sig-keys` |

  `<config_dir>` is `$configDir` in binary mode and `/config` in docker mode.


**Note:** [ethlambda flags PR](https://github.com/lambdaclass/ethlambda/pull/321) will be merged once this PR is approved, as stated in @MegaRedHand's comment [here](https://github.com/lambdaclass/ethlambda/pull/321#pullrequestreview-4208189302).