### PR TITLE
chore: update zeam CLI flags from underscores to hyphens

### DIFF
--- a/ansible/roles/zeam/tasks/main.yml
+++ b/ansible/roles/zeam/tasks/main.yml
@@ -101,12 +101,12 @@
         {{ zeam_docker_image }}
         {{ zeam_global_flags }}
         node
-        --custom_genesis /config
-        --validator_config /config
+        --custom-genesis /config
+        --validator-config /config
         --data-dir /data
         --node-id {{ node_name }}
         --node-key /config/{{ node_name }}.key
-        --metrics_enable
+        --metrics-enable
         --api-port {{ zeam_api_port }}
         --metrics-port {{ zeam_metrics_port }}
         {{ '--is-aggregator' if (zeam_is_aggregator | default('false')) == 'true' else '' }}

--- a/client-cmds/zeam-cmd.sh
+++ b/client-cmds/zeam-cmd.sh
@@ -4,7 +4,7 @@
 # setup where lean-quickstart is a submodule folder in zeam repo
 # update the path to your binary here if you want to use binary
 # Metrics enabled by default
-metrics_flag="--metrics_enable"
+metrics_flag="--metrics-enable"
 
 # Optional global zeam CLI flags before `node` (e.g. --console-log-level debug).
 # Default empty: blockblaz/zeam:devnet3 and older binaries do not support top-level log flags.
@@ -30,8 +30,8 @@ if [ -n "${checkpoint_sync_url:-}" ]; then
 fi
 
 node_binary="$scriptDir/../zig-out/bin/zeam $zeam_global_flags node \
-      --custom_genesis $configDir \
-      --validator_config $validatorConfig \
+      --custom-genesis $configDir \
+      --validator-config $validatorConfig \
       --data-dir $dataDir/$item \
       --node-id $item --node-key $configDir/$item.key \
       $metrics_flag \
@@ -42,8 +42,8 @@ node_binary="$scriptDir/../zig-out/bin/zeam $zeam_global_flags node \
       $checkpoint_sync_flag"
 
 node_docker="--security-opt seccomp=unconfined blockblaz/zeam:devnet3 $zeam_global_flags node \
-      --custom_genesis /config \
-      --validator_config $validatorConfig \
+      --custom-genesis /config \
+      --validator-config $validatorConfig \
       --data-dir /data \
       --node-id $item --node-key /config/$item.key \
       $metrics_flag \

--- a/docs/adding-a-new-client.md
+++ b/docs/adding-a-new-client.md
@@ -190,7 +190,7 @@ node_setup="docker"
 |---|---|
 | `--node-id <name>` | Identifies the node in logs and config lookups |
 | `--node-key <path>` | Path to the P2P libp2p private key file |
-| `--genesis` / `--custom_genesis` / `--network` | Path to `config.yaml` (or directory containing it) |
+| `--genesis` / `--custom-genesis` / `--network` | Path to `config.yaml` (or directory containing it) |
 | `--validators` / `--validator-registry-path` | Path to `validators.yaml` (index assignments) |
 | `--bootnodes` | Path to `nodes.yaml` (ENRs for peer discovery) |
 | `--metrics-port <port>` | Prometheus metrics endpoint |


### PR DESCRIPTION
## chore: update zeam CLI flags from underscores to hyphens

Companion to blockblaz/zeam#795

### Context

Zeam is standardizing all CLI flags to use hyphens instead of underscores. This PR updates lean-quickstart to match.

### Changes

- `client-cmds/zeam-cmd.sh`: updated `--custom_genesis`, `--validator_config`, `--metrics_enable` to use hyphens
- `ansible/roles/zeam/tasks/main.yml`: same flag updates in the Docker run command
- `docs/adding-a-new-client.md`: updated `--custom_genesis` reference in the CLI flags table

Only flags passed to the zeam binary were changed. Internal shell variables and Ansible variables are unchanged.

cc @ch4r10t33r