### PR TITLE
feat(zeam): thread --chain-worker flag from ZEAM_CHAIN_WORKER env

### DIFF
--- a/ansible/roles/zeam/defaults/main.yml
+++ b/ansible/roles/zeam/defaults/main.yml
@@ -14,6 +14,16 @@ zeam_global_flags: ""
 # On-disk store for zeam node (requires zeam with --db-backend). Keep in sync with client-cmds/zeam-cmd.sh.
 zeam_db_backend: "lmdb"
 
+# Chain-worker thread routing (zeam #803 slice c-2b/c-2c).
+# Set to "on" to enable the c-2c part 2 burn-in once a zeam build with
+# chain-worker support (>= v0.4.14) is published as blockblaz/zeam:devnet4.
+# Set to "off" to explicitly request the legacy synchronous path on a
+# c-1+ build (kill-switch). Empty default = no flag emitted, so this is
+# a strict no-op against the currently-published v0.4.13 image which
+# doesn't recognise --chain-worker. Keep in sync with
+# client-cmds/zeam-cmd.sh's ZEAM_CHAIN_WORKER env handling.
+zeam_chain_worker: ""
+
 # These should be passed from the playbook
 node_name: ""
 genesis_dir: ""

--- a/ansible/roles/zeam/tasks/main.yml
+++ b/ansible/roles/zeam/tasks/main.yml
@@ -137,6 +137,7 @@
         {{ ('--aggregate-subnet-ids ' + zeam_aggregate_subnet_ids) if (zeam_is_aggregator | default('false')) == 'true' and (',' in zeam_aggregate_subnet_ids | default('')) else '' }}
         {{ ('--checkpoint-sync-url ' + checkpoint_sync_url) if (checkpoint_sync_url is defined and checkpoint_sync_url | length > 0) else '' }}
         {{ ('--db-backend ' + zeam_db_backend) if (zeam_db_backend | default('') | length > 0) else '' }}
+        {{ ('--chain-worker ' + zeam_chain_worker) if (zeam_chain_worker | default('') | length > 0) else '' }}
       register: zeam_container_result
       changed_when: zeam_container_result.rc == 0
 

--- a/client-cmds/zeam-cmd.sh
+++ b/client-cmds/zeam-cmd.sh
@@ -43,6 +43,42 @@ fi
 zeam_db_backend="${ZEAM_DB_BACKEND:-lmdb}"
 db_backend_flag="--db-backend ${zeam_db_backend}"
 
+# Chain-worker thread routing (zeam #803 slice c-2b/c-2c).
+#
+# When `ZEAM_CHAIN_WORKER=on`, zeam runs gossip-block + gossip-attestation
+# producer-side handlers through a dedicated worker thread that owns the
+# BeamChain.states map; cross-thread readers (HTTP API, metrics scrape,
+# event broadcaster) skip the rwlock and use refcount-gated borrows. Aim
+# is the c-2c part 2 burn-in: ≥24h on devnet4 with this flag on, watching
+# `zeam_lock_hold_seconds{site="onBlock.commit"}` p99 (should drop) and
+# `lean_chain_state_refcount_distribution` (typical=1, never >16).
+#
+# Default empty: this PR is a strict no-op against any zeam build,
+# including the currently-published `zeam:devnet4` (v0.4.13, pre-c-1)
+# which does not recognise `--chain-worker` at all. The flag is ONLY
+# emitted when ZEAM_CHAIN_WORKER is explicitly set to `on` or `off`.
+#
+# To enable the burn-in once v0.4.14 (or later) is published as
+# `blockblaz/zeam:devnet4`:
+#   export ZEAM_CHAIN_WORKER=on
+# before running spin-node.sh / ansible. To explicitly request the
+# legacy synchronous path on a c-1+ build (kill-switch):
+#   export ZEAM_CHAIN_WORKER=off
+zeam_chain_worker="${ZEAM_CHAIN_WORKER:-}"
+chain_worker_flag=""
+case "$zeam_chain_worker" in
+    on|off)
+        chain_worker_flag="--chain-worker $zeam_chain_worker"
+        ;;
+    "")
+        # Unset / empty — no flag, zeam takes its compiled-in default
+        # (which is `off` for the chain-worker per #828).
+        ;;
+    *)
+        echo "WARN(zeam-cmd): ZEAM_CHAIN_WORKER='$zeam_chain_worker' is not 'on' or 'off'; ignoring (no --chain-worker flag passed)" >&2
+        ;;
+esac
+
 node_binary="$scriptDir/../zig-out/bin/zeam $zeam_global_flags node \
       --custom_genesis $configDir \
       --validator_config $validatorConfig \
@@ -55,7 +91,8 @@ node_binary="$scriptDir/../zig-out/bin/zeam $zeam_global_flags node \
       $aggregator_flag \
       $aggregate_subnet_ids_flag \
       $checkpoint_sync_flag \
-      $db_backend_flag"
+      $db_backend_flag \
+      $chain_worker_flag"
 
 node_docker="--security-opt seccomp=unconfined blockblaz/zeam:devnet4 $zeam_global_flags node \
       --custom_genesis /config \
@@ -69,7 +106,8 @@ node_docker="--security-opt seccomp=unconfined blockblaz/zeam:devnet4 $zeam_glob
       $aggregator_flag \
       $aggregate_subnet_ids_flag \
       $checkpoint_sync_flag \
-      $db_backend_flag"
+      $db_backend_flag \
+      $chain_worker_flag"
 
 # choose either binary or docker
 node_setup="docker"


### PR DESCRIPTION
Adds an env-gated `--chain-worker {on|off}` flag for the **slice c-2c part 2 burn-in** on devnet4 (zeam [#803](https://github.com/blockblaz/zeam/issues/803), [#828](https://github.com/blockblaz/zeam/pull/828)). Threaded through **both** deployment paths so the live ansible-driven devnet4 playbooks pick it up:

1. **`client-cmds/zeam-cmd.sh`** — reads `ZEAM_CHAIN_WORKER` env, validates against `{on, off, empty}`, appends `--chain-worker <val>` to `node_binary` and `node_docker` only when explicitly set. Used by `spin-node.sh` / any script-driven run.
2. **`ansible/roles/zeam/{defaults,tasks}/main.yml`** — new `zeam_chain_worker` ansible variable (empty default), threaded into the `docker run` templated command. Without this, the script-side change wouldn't take effect on the actual devnet4 ansible deployment because the role re-derives the docker run line itself rather than sourcing the script. (Caught by @ch4r10t33r reviewing this PR.)

## Default behavior: strict no-op

`ZEAM_CHAIN_WORKER` (script) and `zeam_chain_worker` (ansible) both default to empty → no flag emitted. This PR is a strict no-op against any zeam build, including the currently-published `blockblaz/zeam:devnet4` (v0.4.13, pre-c-1) which does not recognise `--chain-worker` at all. Land safely; flip-on later via env / `-e` / group_vars.

## How to enable burn-in

Once a zeam build with chain-worker support is published as `blockblaz/zeam:devnet4` (target: v0.4.14, [zeam release PR](https://github.com/blockblaz/zeam/pull/829)):

```sh
# via script:
export ZEAM_CHAIN_WORKER=on
./spin-node.sh ...

# via ansible:
ansible-playbook ... -e zeam_chain_worker=on
# or set in inventory group_vars/zeam.yml:
#   zeam_chain_worker: "on"
```

To explicitly run the legacy synchronous path on a c-1+ build (kill-switch): substitute `off` for `on` above.

## Burn-in target (per zeam #803 c-2c plan)

- ≥24h with `--chain-worker=on`
- Watch `zeam_lock_hold_seconds{lock="states", site="onBlock.commit"}` p99 — should drop dramatically vs slice (b) baseline (rwlock no longer load-bearing under chain-worker single-writer regime).
- Watch `lean_chain_state_refcount_distribution` — typical=1, occasional 2-4, never >16 (entries stuck >16 indicate a leaked reader acquire).
- Watch `lean_chain_queue_dropped_total` — should be 0 under nominal load; non-zero means producer/consumer mismatch worth investigating.

## Validation

```sh
$ bash -n client-cmds/zeam-cmd.sh && echo OK
OK

# Default (no env): no --chain-worker flag in node cmd line ✅
# ZEAM_CHAIN_WORKER=on:  --chain-worker on appended ✅
# ZEAM_CHAIN_WORKER=off: --chain-worker off appended ✅
# ZEAM_CHAIN_WORKER=hello: WARN logged, no flag emitted ✅
```

Ansible side is parallel to the existing `--db-backend` plumbing (same template idiom: `{{ ('--flag ' + var) if (var | length > 0) else '' }}`).

## Followups

After burn-in clean, two separate PRs:
1. **zeam side:** flip the compiled-in default of `--chain-worker` from `off` → `on` (one-line, in zeam repo).
2. **lean-quickstart side:** can drop the env-gating from this file once the zeam default flips.
