### PR TITLE
fix(ansible): per-play strategy=free; compatible with add_host

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -88,7 +88,7 @@ docker ps | grep zeam_0
 
 ## Parallelism (large devnets)
 
-`ansible.cfg` sets **`strategy = free`** and a **`forks`** fallback for bare `ansible-playbook` invocations.
+`ansible.cfg` sets **`forks`** as a fallback for bare `ansible-playbook` invocations. **`strategy = free`** is not set globally because it is incompatible with **`add_host`** (used by deploy/stop/clean/copy-genesis). Remote plays that benefit use **`strategy: free`** in the playbook; plays that run **`add_host`** stay on the default **linear** strategy.
 
 **`run-ansible.sh`** and **`ansible-deploy.sh`** pass **`-f N`** where `N` comes from counting **unique `enrFields.ip`** values in the active `validator-config.yaml` (via `ansible/compute-forks-from-validator-config.sh`), clamped between **`LEAN_ANSIBLE_FORKS_MIN`** (default `5`) and **`LEAN_ANSIBLE_FORKS_MAX`** (default `128`). The minimum avoids fully serializing deploys when every validator row shares one IP (many nodes, one machine) while still reflecting larger devnets by unique address.
 

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -11,14 +11,12 @@ display_skipped_hosts = False
 display_ok_hosts = True
 deprecation_warnings = False
 
-# Large devnets: use strategy=free so hosts do not wait on each other at every task.
-# Concurrent sessions: run-ansible.sh / ansible-deploy.sh pass -f from unique
-# enrFields.ip in validator-config (see compute-forks-from-validator-config.sh).
-# This value applies when ansible-playbook is run without -f and ANSIBLE_FORKS is unset.
+# Large devnets: run-ansible.sh / ansible-deploy.sh pass -f from unique enrFields.ip.
+# Do not set strategy=free globally — it breaks playbooks that use add_host (deploy-nodes,
+# stop-nodes, clean-node-data, copy-genesis). Parallel host execution uses per-play
+# strategy: free where safe; default remains linear.
 # Override: ANSIBLE_FORKS=50 ansible-playbook ...  or  ansible-playbook -f 50 ...
-# For strict lockstep: ANSIBLE_STRATEGY=linear
 forks = 25
-strategy = free
 # SSH private key file (can be overridden per-host in inventory or via environment variable)
 # Defaults to ~/.ssh/id_rsa if not specified
 # To use a different key, either:

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -1,7 +1,7 @@
 ---
 # Global variables for all nodes
 #
-# Parallel runs: ansible/ansible.cfg sets strategy=free and forks=25 as fallback when
+# Parallel runs: ansible/ansible.cfg sets forks=25 as fallback when
 # no -f is passed. run-ansible.sh and ansible-deploy.sh set -f from unique enrFields.ip
 # in validator-config (clamped by LEAN_ANSIBLE_FORKS_MIN / LEAN_ANSIBLE_FORKS_MAX).
 # Override forks: ANSIBLE_FORKS=100 or ansible-playbook -f 100 ...

--- a/ansible/playbooks/clean-node-data.yml
+++ b/ansible/playbooks/clean-node-data.yml
@@ -103,6 +103,7 @@
 
 - name: Clean node data directories on remote hosts
   hosts: clean_targets
+  strategy: free
   gather_facts: no
   vars:
     # Use remote paths on remote hosts

--- a/ansible/playbooks/deploy-nodes.yml
+++ b/ansible/playbooks/deploy-nodes.yml
@@ -99,6 +99,7 @@
 
 - name: Deploy nodes on remote hosts
   hosts: deployment_targets
+  strategy: free
   gather_facts: yes
   vars:
     # Use remote paths on remote hosts
@@ -248,6 +249,7 @@
 # When --replace-with is used, sync updated config yamls to all remote hosts
 - name: Sync updated config files to all hosts after replacement
   hosts: all:!local
+  strategy: free
   gather_facts: no
   vars:
     genesis_dir: "{{ remote_genesis_dir | default('/opt/lean-quickstart/genesis') }}"

--- a/ansible/playbooks/prepare.yml
+++ b/ansible/playbooks/prepare.yml
@@ -44,6 +44,7 @@
 
 - name: Prepare remote servers
   hosts: all:!localhost
+  strategy: free
   gather_facts: yes
   vars:
     # network_dir is passed as an extra var by run-ansible.sh; fall back to

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -18,8 +18,8 @@
 #   skip_genesis     - Set to true to skip genesis generation (default: false)
 #   genesis_offset   - Seconds to add to current time for genesis (default: 360 for ansible mode)
 #
-# Parallelism: ansible.cfg uses strategy=free; run-ansible / ansible-deploy pass -f from
-# unique enrFields.ip in validator-config unless ANSIBLE_FORKS is set.
+# Parallelism: remote plays use strategy=free where safe; run-ansible / ansible-deploy pass
+# -f from unique enrFields.ip in validator-config unless ANSIBLE_FORKS is set.
 
 - name: Clean Data Directories
   import_playbook: clean-node-data.yml

--- a/ansible/playbooks/stop-nodes.yml
+++ b/ansible/playbooks/stop-nodes.yml
@@ -78,6 +78,7 @@
 
 - name: Stop nodes on remote hosts
   hosts: stop_targets
+  strategy: free
   gather_facts: yes
   vars:
     node_name: "{{ inventory_hostname }}"


### PR DESCRIPTION
## Problem

Ansible fails when `ansible.cfg` sets global `strategy = free` and a playbook uses `add_host`:

> The 'add_host' module bypasses the host loop, which is currently not supported in the free strategy

This affected `stop-nodes.yml`, `deploy-nodes.yml`, `clean-node-data.yml`, and `copy-genesis.yml` (dynamic groups via `add_host`).

## Change

- Remove global `strategy = free` from `ansible/ansible.cfg` (keep `forks` tuning and document the constraint).
- Set `strategy: free` only on plays that do **not** use `add_host`: `prepare.yml`, remote deploy/sync plays in `deploy-nodes.yml`, `stop-nodes.yml` remote play, `clean-node-data.yml` remote play.
- Update `ansible/README.md`, `site.yml` header, and `inventory/group_vars/all.yml` comments.

## Verification

`ansible-playbook --syntax-check` on the touched playbooks passes.